### PR TITLE
Fix bundle identifier from React Native example to me.blirp.app

### DIFF
--- a/apple-app-site-association
+++ b/apple-app-site-association
@@ -2,7 +2,7 @@
   "applinks": {
     "details": [
       {
-        "appIDs": ["25GGA9M3A7.org.reactjs.native.example.BlirpMe"],
+        "appIDs": ["25GGA9M3A7.me.blirp.app"],
         "components": [
           {
             "/": "*",
@@ -13,7 +13,7 @@
     ]
   },
   "webcredentials": {
-    "apps": ["25GGA9M3A7.org.reactjs.native.example.BlirpMe"]
+    "apps": ["25GGA9M3A7.me.blirp.app"]
   },
   "appclips": {
     "apps": []

--- a/blirp-me-site/.well-known/apple-app-site-association
+++ b/blirp-me-site/.well-known/apple-app-site-association
@@ -2,7 +2,7 @@
   "applinks": {
     "details": [
       {
-        "appIDs": ["25GGA9M3A7.org.reactjs.native.example.BlirpMe"],
+        "appIDs": ["25GGA9M3A7.me.blirp.app"],
         "components": [
           {
             "/": "*",
@@ -13,7 +13,7 @@
     ]
   },
   "webcredentials": {
-    "apps": ["25GGA9M3A7.org.reactjs.native.example.BlirpMe"]
+    "apps": ["25GGA9M3A7.me.blirp.app"]
   },
   "appclips": {
     "apps": []

--- a/blirp-me-site/apple-app-site-association
+++ b/blirp-me-site/apple-app-site-association
@@ -2,7 +2,7 @@
   "applinks": {
     "details": [
       {
-        "appIDs": ["25GGA9M3A7.org.reactjs.native.example.BlirpMe"],
+        "appIDs": ["25GGA9M3A7.me.blirp.app"],
         "components": [
           {
             "/": "*",
@@ -13,7 +13,7 @@
     ]
   },
   "webcredentials": {
-    "apps": ["25GGA9M3A7.org.reactjs.native.example.BlirpMe"]
+    "apps": ["25GGA9M3A7.me.blirp.app"]
   },
   "appclips": {
     "apps": []

--- a/blirp-me-site/apple-app-site-association.json
+++ b/blirp-me-site/apple-app-site-association.json
@@ -2,7 +2,7 @@
   "applinks": {
     "details": [
       {
-        "appIDs": ["25GGA9M3A7.org.reactjs.native.example.BlirpMe"],
+        "appIDs": ["25GGA9M3A7.me.blirp.app"],
         "components": [
           {
             "/": "*",
@@ -13,7 +13,7 @@
     ]
   },
   "webcredentials": {
-    "apps": ["25GGA9M3A7.org.reactjs.native.example.BlirpMe"]
+    "apps": ["25GGA9M3A7.me.blirp.app"]
   },
   "appclips": {
     "apps": []

--- a/ios/BlirpMe.xcodeproj/project.pbxproj
+++ b/ios/BlirpMe.xcodeproj/project.pbxproj
@@ -41,7 +41,7 @@
 		00E356EE1AD99517003FC87E /* BlirpMeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BlirpMeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* BlirpMeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BlirpMeTests.m; sourceTree = "<group>"; };
-		13B07F961A680F5B00A75B9A /* Blirp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Blirp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07F961A680F5B00A75B9A /* BlirpMe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BlirpMe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = BlirpMe/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = BlirpMe/AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = BlirpMe/Images.xcassets; sourceTree = "<group>"; };
@@ -158,7 +158,7 @@
 		83CBBA001A601CBA00E9B192 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				13B07F961A680F5B00A75B9A /* Blirp.app */,
+				13B07F961A680F5B00A75B9A /* BlirpMe.app */,
 				00E356EE1AD99517003FC87E /* BlirpMeTests.xctest */,
 			);
 			name = Products;
@@ -266,7 +266,7 @@
 			);
 			name = BlirpMe;
 			productName = BlirpMe;
-			productReference = 13B07F961A680F5B00A75B9A /* Blirp.app */;
+			productReference = 13B07F961A680F5B00A75B9A /* BlirpMe.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -586,7 +586,8 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = Blirp;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = me.blirp.app;
+				PRODUCT_NAME = BlirpMe;
 				SWIFT_OBJC_BRIDGING_HEADER = "BlirpMe/BlirpMe-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -617,7 +618,8 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = Blirp;
+				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = me.blirp.app;
+				PRODUCT_NAME = BlirpMe;
 				SWIFT_OBJC_BRIDGING_HEADER = "BlirpMe/BlirpMe-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/ios/BlirpMe.xcodeproj/project.pbxproj
+++ b/ios/BlirpMe.xcodeproj/project.pbxproj
@@ -585,8 +585,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = me.blirp.app;
+				PRODUCT_BUNDLE_IDENTIFIER = me.blirp.app;
 				PRODUCT_NAME = BlirpMe;
 				SWIFT_OBJC_BRIDGING_HEADER = "BlirpMe/BlirpMe-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -617,8 +616,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
-				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = me.blirp.app;
+				PRODUCT_BUNDLE_IDENTIFIER = me.blirp.app;
 				PRODUCT_NAME = BlirpMe;
 				SWIFT_OBJC_BRIDGING_HEADER = "BlirpMe/BlirpMe-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -700,6 +698,7 @@
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
 				OTHER_LDFLAGS = "$(inherited)  ";
+				PRODUCT_NAME = Blirp;
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -773,6 +772,7 @@
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
 				OTHER_LDFLAGS = "$(inherited)  ";
+				PRODUCT_NAME = Blirp;
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/ios/BlirpMe/BlirpMe.entitlements
+++ b/ios/BlirpMe/BlirpMe.entitlements
@@ -13,10 +13,6 @@
 	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>
-	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array>
-		<string>iCloud.$(CFBundleIdentifier)</string>
-	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 </dict>


### PR DESCRIPTION
## Summary
- Fixed bundle identifier references from `org.reactjs.native.example.BlirpMe` to `me.blirp.app`
- Removed iCloud container entitlement that was causing provisioning profile errors
- Updated all apple-app-site-association files for proper Passkey domain verification

## Changes
- Updated 4 apple-app-site-association files to use correct bundle ID
- Removed `com.apple.developer.icloud-container-identifiers` from entitlements
- CloudBackup feature uses keychain (via Passkeys) so iCloud container is not needed